### PR TITLE
make sure to add correct end boundary for input

### DIFF
--- a/src/main/java/com/packt/datastructuresandalg/lesson2/sorting/BinarySearchRecursive.java
+++ b/src/main/java/com/packt/datastructuresandalg/lesson2/sorting/BinarySearchRecursive.java
@@ -3,7 +3,7 @@ package com.packt.datastructuresandalg.lesson2.sorting;
 
 public class BinarySearchRecursive {
     public boolean binarySearch(int x, int[] sortedNumbers) {
-        return binarySearch(x, sortedNumbers, 0, sortedNumbers.length);
+        return binarySearch(x, sortedNumbers, 0, sortedNumbers.length - 1);
     }
 
     public boolean binarySearch(int x, int[] sortedNumbers, int start, int end) {

--- a/src/test/java/com/packt/datastructuresandalg/lesson2/sorting/BinarySearchRecursiveTest.java
+++ b/src/test/java/com/packt/datastructuresandalg/lesson2/sorting/BinarySearchRecursiveTest.java
@@ -1,0 +1,44 @@
+package com.packt.datastructuresandalg.lesson2.sorting;
+
+import org.junit.Before;
+import org.junit.Test;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class BinarySearchRecursiveTest {
+
+    private BinarySearchRecursive sut;
+    @Before
+    public void setUp() {
+        sut = new BinarySearchRecursive();
+    }
+
+    @Test
+    public void shouldNotFindElementGreaterThanLastInputElement() {
+        boolean result = sut.binarySearch(12, new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        assertFalse("12 is not included in the input", result);
+    }
+    @Test
+    public void shouldNotFindElementSmallerThanFirstInputElement() {
+        boolean result = sut.binarySearch(0, new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        assertFalse("0 is not included in the input", result);
+    }
+
+    @Test
+    public void shouldFindElementFromEndOfInput() {
+        boolean result = sut.binarySearch(10, new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        assertTrue("10 is included in the input", result);
+    }
+    @Test
+    public void shouldFindElementFromStartOfInput() {
+        boolean result = sut.binarySearch(1, new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        assertTrue("1 is included in the input", result);
+    }
+
+    @Test
+    public void shouldFindElementInMiddleOfInput() {
+        boolean result = sut.binarySearch(7, new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10});
+        assertTrue("7 is included in the input", result);
+    }
+
+}


### PR DESCRIPTION
binary search recursive implementation does not handle correctly scenario when an element to search for is greater than the last input element by throwing the following exception:
java.lang.ArrayIndexOutOfBoundsException: 10
	at com.packt.datastructuresandalg.lesson2.sorting.BinarySearchRecursive.binarySearch(BinarySearchRecursive.java:12)

to fix it you need to make sure that in recursive binary search helper method you pass index of last element by subtracting 1 from the length of the input, not the length of the input